### PR TITLE
Sliding hue slider no longer resets saturation and value.

### DIFF
--- a/colorpicker.js
+++ b/colorpicker.js
@@ -188,9 +188,9 @@
             evt = evt || window.event;
             var mouse = mousePosition(evt);
             ctx.h = mouse.y / slideElement.offsetHeight * 360 + hueOffset;
-            ctx.s = ctx.v = 1;
-            var c = hsv2rgb({ h: ctx.h, s: 1, v: 1 });
-            pickerElement.style.backgroundColor = c.hex;
+            var pickerColor = hsv2rgb({ h: ctx.h, s: 1, v: 1 });
+            var c = hsv2rgb({ h: ctx.h, s: ctx.s, v: ctx.v });
+            pickerElement.style.backgroundColor = pickerColor.hex;
             ctx.callback && ctx.callback(c.hex, { h: ctx.h - hueOffset, s: ctx.s, v: ctx.v }, { r: c.r, g: c.g, b: c.b }, undefined, mouse);
         }
     };
@@ -423,9 +423,6 @@
     ColorPicker.positionIndicators = function(slideIndicator, pickerIndicator, mouseSlide, mousePicker) {
         
         if (mouseSlide) {
-            pickerIndicator.style.left = 'auto';
-            pickerIndicator.style.right = '0px';
-            pickerIndicator.style.top = '0px';
             slideIndicator.style.top = (mouseSlide.y - slideIndicator.offsetHeight/2) + 'px';
         }
         if (mousePicker) {


### PR DESCRIPTION
When the hue slider is moved, two colors are now created. One fully saturated and bright value for the picker area, and one color where only the Hue from the HSV triplet has been changed. The latter is used for the callbacks.

Additionally, the picker dot is no longer moved to the top right corner when the hue slider is moved.

This resolves #8.
