### PR TITLE
Use getElementsByTagName for Safari

### DIFF
--- a/colorpicker.js
+++ b/colorpicker.js
@@ -264,14 +264,15 @@
             var slideClone = slide.cloneNode(true);
             var pickerClone = picker.cloneNode(true);
             
-            var hsvGradient = slideClone.getElementById('gradient-hsv');
+            var hsvGradient = slideClone.getElementsByTagName('linearGradient')[0];
             
             var hsvRect = slideClone.getElementsByTagName('rect')[0];
             
             hsvGradient.id = 'gradient-hsv-' + uniqID;
             hsvRect.setAttribute('fill', 'url(#' + hsvGradient.id + ')');
 
-            var blackAndWhiteGradients = [pickerClone.getElementById('gradient-black'), pickerClone.getElementById('gradient-white')];
+            var pickerGradients = pickerClone.getElementsByTagName('linearGradient');
+            var blackAndWhiteGradients = [pickerGradients[0], pickerGradients[1]];
             var whiteAndBlackRects = pickerClone.getElementsByTagName('rect');
             
             blackAndWhiteGradients[0].id = 'gradient-black-' + uniqID;


### PR DESCRIPTION
Safari is having issues for some reason with getElementById for the cloned SVG object. Switching to getElementsByTagName seems to fix the problem. I didn't know what js minify library was used so the I didn't update min.js. This should fix #29.
