### PR TITLE
three new methods, disableEvents, disablePicker and destroyNodes

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -13,7 +13,7 @@
 
     <script type="text/javascript">
 
-      ColorPicker(
+      var ColorPicker = new ColorPicker(
 
         document.getElementById('slider'),
         document.getElementById('picker'),


### PR DESCRIPTION
As it was requested in issue #32 . I have added three new methods:

- `disableEvents` which will be disabling events of entire picker.
- `destroyNodes` which will remove picker and slider.
- `disablePicker` which will use both methods mentioned above.